### PR TITLE
Fix internal library name

### DIFF
--- a/AMBuilder
+++ b/AMBuilder
@@ -6,7 +6,7 @@ def AddSourceFilesFromDir(path, files):
     list.append(os.path.join(path, file))
   return list
 
-libsafetyhook = builder.StaticLibraryProject('libsafetyhook')
+libsafetyhook = builder.StaticLibraryProject('safetyhook')
 # SafetyHook sourcefiles
 libsafetyhook.sources = AddSourceFilesFromDir(os.path.join(builder.currentSourcePath, 'src'),[
   "allocator.cpp",


### PR DESCRIPTION
Currently produced .lib/.a file would be named as ``libsafetyhook.lib`` and ``liblibsafetyhook.a`` accordingly, which isn't really following any other lib naming stuff (also the double lib is because ambuild already appends ``lib`` prefix for .a libraries)