### PR TITLE
Fix GCC compile errors

### DIFF
--- a/AMBuilder
+++ b/AMBuilder
@@ -56,6 +56,7 @@ for compiler in SafetyHook.all_targets:
     ]
     compiler.cxxflags += [
       "-Wnon-virtual-dtor",
+      "-Wno-format",
       "-std=c++17"
     ]
     binary.sources += [ os.path.join(builder.currentSourcePath, 'src', 'os.linux.cpp') ]


### PR DESCRIPTION
GCC doesn't likes some of the sscanf usage inside the safetyhook (``src/os.linux.cpp:116:43``) where unsigned/signed usage is mixed, this mutes these errors and lets it build.

Errors that are thrown:
``error: format ‘%x’ expects argument of type ‘unsigned int*’, but argument 8 has type ‘int*’``
![image](https://github.com/alliedmodders/safetyhook/assets/31375974/dba69562-5d3d-449a-933d-a15a226ddad8)
