### PR TITLE
Correctly initialize std::optional value

### DIFF
--- a/src/os.linux.cpp
+++ b/src/os.linux.cpp
@@ -117,6 +117,7 @@ std::expected<VmBasicInfo, OsError> vm_query(uint8_t* address) {
             &inode, path);
 
         if (last_end < start && addr >= last_end && addr < start) {
+            info.emplace();
             info->address = reinterpret_cast<uint8_t*>(last_end);
             info->size = start - last_end;
             info->access = VmAccess();
@@ -128,6 +129,7 @@ std::expected<VmBasicInfo, OsError> vm_query(uint8_t* address) {
         last_end = end;
 
         if (addr >= start && addr < end) {
+            info.emplace();
             info->address = reinterpret_cast<uint8_t*>(start);
             info->size = end - start,
             info->access = VmAccess();


### PR DESCRIPTION
This fixes issues/crashes on linux, as info object wasn't correctly initialized thus leading to incorrect behavior later.