### PR TITLE
Add option to create debug builds

### DIFF
--- a/AMBuilder
+++ b/AMBuilder
@@ -22,7 +22,8 @@ libsafetyhook.sources += AddSourceFilesFromDir(os.path.join(builder.currentSourc
 ])
 
 for compiler in SafetyHook.all_targets:
-  binary = libsafetyhook.Configure(compiler, libsafetyhook.name, 'Release - {0}'.format(compiler.target.arch))
+  tag = 'Debug' if builder.options.debug == '1' else 'Release'
+  binary = libsafetyhook.Configure(compiler, libsafetyhook.name, '{0} - {1}'.format(tag, compiler.target.arch))
   # Configure the binary's compiler
   compiler = binary.compiler
   # Reset all flags, safetyhook requires specific compilation flags
@@ -32,7 +33,16 @@ for compiler in SafetyHook.all_targets:
   compiler.includes = []
   compiler.cxxincludes = []
 
+  # Debugging
+  if builder.options.debug == '1':
+    compiler.defines += ['DEBUG', '_DEBUG']
+
   if compiler.target.platform == 'windows':
+    if builder.options.debug == '1':
+      compiler.cflags += ['/MTd', '/Od', '/RTC1']
+      compiler.defines += ['_ITERATOR_DEBUG_LEVEL=0']
+    else:
+      compiler.cflags += ['/MT']
     compiler.cflags += [
       "/W4",
     ]

--- a/configure.py
+++ b/configure.py
@@ -4,4 +4,6 @@ from ambuild2 import run
 parser = run.BuildParser(sourcePath = sys.path[0], api='2.2')
 parser.options.add_argument('--targets', type=str, dest='targets', default=None,
 		                help="Override the target architecture (use commas to separate multiple targets).")
+parser.options.add_argument('--enable-debug', action='store_const', const='1', dest='debug',
+                       help='Enable debugging symbols')
 parser.Configure()


### PR DESCRIPTION
This allows to link sourcemod with `--enable-debug` on Windows.