### PR TITLE
Fix building on CMake on C++ 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${safetyhook_SOURCES})
 
 add_library(safetyhook::safetyhook ALIAS safetyhook)
 target_compile_features(safetyhook PUBLIC
-	cxx_std_23
+	cxx_std_20
 )
 
 if(MSVC) # msvc
@@ -219,7 +219,7 @@ if(SAFETYHOOK_BUILD_EXAMPLES) # build-examples
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${example-minimal_SOURCES})
 
 	target_compile_features(example-minimal PRIVATE
-		cxx_std_23
+		cxx_std_20
 	)
 
 	target_link_libraries(example-minimal PRIVATE
@@ -245,7 +245,7 @@ if(SAFETYHOOK_BUILD_EXAMPLES) # build-examples
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${example-multiple_SOURCES})
 
 	target_compile_features(example-multiple PRIVATE
-		cxx_std_23
+		cxx_std_20
 	)
 
 	target_link_libraries(example-multiple PRIVATE
@@ -271,7 +271,7 @@ if(SAFETYHOOK_BUILD_EXAMPLES) # build-examples
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${example-midhook_SOURCES})
 
 	target_compile_features(example-midhook PRIVATE
-		cxx_std_23
+		cxx_std_20
 	)
 
 	target_link_libraries(example-midhook PRIVATE
@@ -297,7 +297,7 @@ if(SAFETYHOOK_BUILD_EXAMPLES) # build-examples
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${example-threadsafe_SOURCES})
 
 	target_compile_features(example-threadsafe PRIVATE
-		cxx_std_23
+		cxx_std_20
 	)
 
 	target_link_libraries(example-threadsafe PRIVATE
@@ -323,7 +323,7 @@ if(SAFETYHOOK_BUILD_EXAMPLES AND WIN32) # windows-only-example
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${example-dll_SOURCES})
 
 	target_compile_features(example-dll PUBLIC
-		cxx_std_23
+		cxx_std_20
 	)
 
 	target_link_libraries(example-dll PUBLIC
@@ -344,7 +344,7 @@ if(SAFETYHOOK_BUILD_EXAMPLES) # build-examples
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${example-vmthook_SOURCES})
 
 	target_compile_features(example-vmthook PRIVATE
-		cxx_std_23
+		cxx_std_20
 	)
 
 	target_link_libraries(example-vmthook PRIVATE
@@ -379,7 +379,7 @@ if(SAFETYHOOK_BUILD_TEST) # build-test
 	)
 
 	target_compile_features(test PRIVATE
-		cxx_std_23
+		cxx_std_20
 	)
 
 	target_link_libraries(test PRIVATE
@@ -417,7 +417,7 @@ if(SAFETYHOOK_BUILD_TEST AND SAFETYHOOK_AMALGAMATE) # build-amalgamate-test
 	)
 
 	target_compile_features(test-amalgamated PRIVATE
-		cxx_std_23
+		cxx_std_20
 	)
 
 	target_include_directories(test-amalgamated PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${safetyhook_SOURCES})
 
 add_library(safetyhook::safetyhook ALIAS safetyhook)
 target_compile_features(safetyhook PUBLIC
-	cxx_std_20
+	cxx_std_17
 )
 
 if(MSVC) # msvc
@@ -219,7 +219,7 @@ if(SAFETYHOOK_BUILD_EXAMPLES) # build-examples
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${example-minimal_SOURCES})
 
 	target_compile_features(example-minimal PRIVATE
-		cxx_std_20
+		cxx_std_17
 	)
 
 	target_link_libraries(example-minimal PRIVATE
@@ -245,7 +245,7 @@ if(SAFETYHOOK_BUILD_EXAMPLES) # build-examples
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${example-multiple_SOURCES})
 
 	target_compile_features(example-multiple PRIVATE
-		cxx_std_20
+		cxx_std_17
 	)
 
 	target_link_libraries(example-multiple PRIVATE
@@ -271,7 +271,7 @@ if(SAFETYHOOK_BUILD_EXAMPLES) # build-examples
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${example-midhook_SOURCES})
 
 	target_compile_features(example-midhook PRIVATE
-		cxx_std_20
+		cxx_std_17
 	)
 
 	target_link_libraries(example-midhook PRIVATE
@@ -297,7 +297,7 @@ if(SAFETYHOOK_BUILD_EXAMPLES) # build-examples
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${example-threadsafe_SOURCES})
 
 	target_compile_features(example-threadsafe PRIVATE
-		cxx_std_20
+		cxx_std_17
 	)
 
 	target_link_libraries(example-threadsafe PRIVATE
@@ -323,7 +323,7 @@ if(SAFETYHOOK_BUILD_EXAMPLES AND WIN32) # windows-only-example
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${example-dll_SOURCES})
 
 	target_compile_features(example-dll PUBLIC
-		cxx_std_20
+		cxx_std_17
 	)
 
 	target_link_libraries(example-dll PUBLIC
@@ -344,7 +344,7 @@ if(SAFETYHOOK_BUILD_EXAMPLES) # build-examples
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${example-vmthook_SOURCES})
 
 	target_compile_features(example-vmthook PRIVATE
-		cxx_std_20
+		cxx_std_17
 	)
 
 	target_link_libraries(example-vmthook PRIVATE
@@ -379,7 +379,7 @@ if(SAFETYHOOK_BUILD_TEST) # build-test
 	)
 
 	target_compile_features(test PRIVATE
-		cxx_std_20
+		cxx_std_17
 	)
 
 	target_link_libraries(test PRIVATE
@@ -417,7 +417,7 @@ if(SAFETYHOOK_BUILD_TEST AND SAFETYHOOK_AMALGAMATE) # build-amalgamate-test
 	)
 
 	target_compile_features(test-amalgamated PRIVATE
-		cxx_std_20
+		cxx_std_17
 	)
 
 	target_include_directories(test-amalgamated PRIVATE

--- a/cmake.toml
+++ b/cmake.toml
@@ -54,7 +54,7 @@ required = true
 type = "static"
 sources = ["src/*.cpp"]
 include-directories = ["include/"]
-compile-features = ["cxx_std_23"]
+compile-features = ["cxx_std_20"]
 alias = "safetyhook::safetyhook"
 link-libraries = ["Zydis"]
 msvc.private-compile-options = ["/permissive-", "/W4", "/w14640"]
@@ -108,13 +108,13 @@ add_custom_target(Amalgamate ALL DEPENDS ${AMALGAMATED_FILE} ${AMALGAMATED_HEADE
 condition = "build-examples"
 type = "executable"
 link-libraries = ["safetyhook::safetyhook"]
-compile-features = ["cxx_std_23"]
+compile-features = ["cxx_std_20"]
 
 [template.example-dll]
 condition = "windows-only-example"
 type = "shared"
 link-libraries = ["safetyhook::safetyhook"]
-compile-features = ["cxx_std_23"]
+compile-features = ["cxx_std_20"]
 
 [target.example-minimal]
 type = "example"
@@ -146,7 +146,7 @@ type = "executable"
 sources = ["test/*.cpp"]
 link-libraries = ["Boost::ut", "safetyhook::safetyhook", "xbyak::xbyak"]
 compile-definitions = ["BOOST_UT_DISABLE_MODULE"]
-compile-features = ["cxx_std_23"]
+compile-features = ["cxx_std_20"]
 
 [target.test-amalgamated]
 condition = "build-amalgamate-test"
@@ -155,7 +155,7 @@ sources = ["test/*.cpp", "amalgamated-dist/safetyhook.cpp"]
 include-directories = ["amalgamated-dist/"]
 link-libraries = ["Zydis", "Boost::ut", "xbyak::xbyak"]
 compile-definitions = ["BOOST_UT_DISABLE_MODULE"]
-compile-features = ["cxx_std_23"]
+compile-features = ["cxx_std_20"]
 cmake-after = """
 add_dependencies(test-amalgamated Amalgamate)
 """

--- a/cmake.toml
+++ b/cmake.toml
@@ -54,7 +54,7 @@ required = true
 type = "static"
 sources = ["src/*.cpp"]
 include-directories = ["include/"]
-compile-features = ["cxx_std_20"]
+compile-features = ["cxx_std_17"]
 alias = "safetyhook::safetyhook"
 link-libraries = ["Zydis"]
 msvc.private-compile-options = ["/permissive-", "/W4", "/w14640"]
@@ -108,13 +108,13 @@ add_custom_target(Amalgamate ALL DEPENDS ${AMALGAMATED_FILE} ${AMALGAMATED_HEADE
 condition = "build-examples"
 type = "executable"
 link-libraries = ["safetyhook::safetyhook"]
-compile-features = ["cxx_std_20"]
+compile-features = ["cxx_std_17"]
 
 [template.example-dll]
 condition = "windows-only-example"
 type = "shared"
 link-libraries = ["safetyhook::safetyhook"]
-compile-features = ["cxx_std_20"]
+compile-features = ["cxx_std_17"]
 
 [target.example-minimal]
 type = "example"
@@ -146,7 +146,7 @@ type = "executable"
 sources = ["test/*.cpp"]
 link-libraries = ["Boost::ut", "safetyhook::safetyhook", "xbyak::xbyak"]
 compile-definitions = ["BOOST_UT_DISABLE_MODULE"]
-compile-features = ["cxx_std_20"]
+compile-features = ["cxx_std_17"]
 
 [target.test-amalgamated]
 condition = "build-amalgamate-test"
@@ -155,7 +155,7 @@ sources = ["test/*.cpp", "amalgamated-dist/safetyhook.cpp"]
 include-directories = ["amalgamated-dist/"]
 link-libraries = ["Zydis", "Boost::ut", "xbyak::xbyak"]
 compile-definitions = ["BOOST_UT_DISABLE_MODULE"]
-compile-features = ["cxx_std_20"]
+compile-features = ["cxx_std_17"]
 cmake-after = """
 add_dependencies(test-amalgamated Amalgamate)
 """


### PR DESCRIPTION
This fixes CMake building for compilers such as GCC 10, Clang 10/14, that support C++ 17, but not 23. Code requires C++ 17 features such as std::optional, works fine on KHook where is also C++ 17 mandatory.