### PR TITLE
Fix VmAccess default constructor.

### DIFF
--- a/include/safetyhook/os.hpp
+++ b/include/safetyhook/os.hpp
@@ -27,7 +27,7 @@ struct VmAccess {
     bool write : 1;
     bool execute : 1;
 
-    constexpr VmAccess() : read(true), write(true), execute(true) {};
+    constexpr VmAccess() : read(false), write(false), execute(false) {};
     constexpr VmAccess(bool pread, bool pwrite, bool pexecute) : read(pread), write(pwrite), execute(pexecute) {};
 
     constexpr bool operator==(const VmAccess& other) const {


### PR DESCRIPTION

## Fix VmAccess default constructor incorrectly initializes members to true Problem.

I encountered crashes or freezes during the `VmtHook::create` process: 

```c++
std::expected<VmtHook, VmtHook::Error> VmtHook::create(void* object) {
    // ...
    for (auto vm = original_vmt; is_executable(*vm); ++vm) { // ← crashes or freezes.
        ++num_vmt_entries;
    }
    //...
}
```

The issue was eventually traced back to the [VmAccess](https://github.com/alliedmodders/safetyhook/blob/5ad69106705bcc9c70e749388ff8ac42eaad850d/include/safetyhook/os.hpp#L25-L36) constructor:

```c++
struct VmAccess { 
    bool read : 1; 
    bool write : 1; 
    bool execute : 1; 
        
    // All members initialized to true.
    // "bool execute : 1" mean allocate 1 bit of storage. doesn't mean default value is 1.
    constexpr VmAccess() : read(true), write(true), execute(true) {}; 
    constexpr VmAccess(bool pread, bool pwrite, bool pexecute) : read(pread), write(pwrite), execute(pexecute) {}; 

    constexpr bool operator==(const VmAccess& other) const { 
        return read == other.read && write == other.write && execute == other.execute; 
    } 
}; 
```

This will cause an error in [vm_query()](https://github.com/alliedmodders/safetyhook/blob/5ad69106705bcc9c70e749388ff8ac42eaad850d/src/os.linux.cpp#L131-L151), where access permissions will always be reported as `true` and will not be set to `false`.

```c++
if (addr >= start && addr < end) {
    info.emplace();
    info->address = reinterpret_cast<uint8_t*>(start);
    info->size = end - start,
    info->access = VmAccess(); // ← All members initialized to true.
    info->is_free = false;

    if (perms[0] == 'r') {
        info->access.read = true;
    }

    if (perms[1] == 'w') {
        info->access.write = true;
    }

    if (perms[2] == 'x') {
        info->access.execute = true;
    }

    break;
}
```

The default constructor of `VmAccess` should be changed to `false` for initialization.

The original `cursey/safetyhook` branch does not have this problem because it doesn't have a `VmAccess` constructor at all and will correctly initialize to `false`.