### PR TITLE
Avoid W^X violation in `trap_threads`

### DIFF
--- a/src/os.linux.cpp
+++ b/src/os.linux.cpp
@@ -185,11 +185,15 @@ SystemInfo system_info() {
 
 void trap_threads([[maybe_unused]] uint8_t* from, [[maybe_unused]] uint8_t* to, [[maybe_unused]] size_t len,
     const std::function<void()>& run_fn) {
-    auto from_protect = vm_protect(from, len, VM_ACCESS_RWX).value_or(0);
-    auto to_protect = vm_protect(to, len, VM_ACCESS_RWX).value_or(0);
+    auto from_protect = vm_protect(from, len, VM_ACCESS_RW);
+    auto to_protect = vm_protect(to, len, VM_ACCESS_RW);
     run_fn();
-    vm_protect(to, len, to_protect);
-    vm_protect(from, len, from_protect);
+    if (to_protect.has_value()) {
+        vm_protect(to, len, to_protect.value());
+    }
+    if (from_protect.has_value()) {
+        vm_protect(from, len, from_protect.value());
+    }
 }
 
 void fix_ip([[maybe_unused]] ThreadContext ctx, [[maybe_unused]] uint8_t* old_ip, [[maybe_unused]] uint8_t* new_ip) {


### PR DESCRIPTION
`trap_threads` patches the target's code while its page is still mapped executable, which trips W^X enforcement and faults on hardened kernels. This avoids the violation during the patch.